### PR TITLE
Updapting `standings` endpoint for `ov1_5+` & `ov2_5` data

### DIFF
--- a/src/routes/api/tournaments_standings/update/cache-surgical.json.ts
+++ b/src/routes/api/tournaments_standings/update/cache-surgical.json.ts
@@ -707,21 +707,15 @@ async function surgicalDataUpdate_2 (dataUpdate: BACKEND_tournament_standings_su
 
         const team_total_ov15: number =
           target_team_stats?.data[0].goal_line?.over["1_5"]?.away == null ||
-          target_team_stats?.data[0]?.goal_line?.over["1_5"]?.home == null ||
-          season_team?.overall?.games_played == null
+          target_team_stats?.data[0]?.goal_line?.over["1_5"]?.home == null 
             ? null
-            : season_team?.overall?.games_played == 0
-              ? 0
-              : (target_team_stats?.data[0].goal_line?.over["1_5"]?.away + target_team_stats?.data[0]?.goal_line?.over["1_5"]?.home) / season_team?.overall?.games_played
+            : (target_team_stats?.data[0].goal_line?.over["1_5"]?.away + target_team_stats?.data[0]?.goal_line?.over["1_5"]?.home) / 2
 
         const team_total_ov25: number =
           target_team_stats?.data[0].goal_line?.over["2_5"]?.away == null ||
-          target_team_stats?.data[0]?.goal_line?.over["2_5"]?.home == null ||
-          season_team?.overall?.games_played == null
+          target_team_stats?.data[0]?.goal_line?.over["2_5"]?.home == null
             ? null
-            : season_team?.overall?.games_played == 0
-              ? 0
-              : (target_team_stats?.data[0].goal_line?.over["2_5"]?.away + target_team_stats?.data[0]?.goal_line?.over["2_5"]?.home) / season_team?.overall?.games_played
+            : (target_team_stats?.data[0].goal_line?.over["2_5"]?.away + target_team_stats?.data[0]?.goal_line?.over["2_5"]?.home) / 2
 
         const team_total_gavg: number = 
           season_team?.round_name == null ||


### PR DESCRIPTION
# 📃 Description

- @migbash updating `tournaments | standings` table to use the correct `ov_1_5+` & `ov_2_5+` column data

**Fixes** 

- #504

## ℹ Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# 🧰 How Has This Been Tested?

- [x] `local-testing`

# ✔ Checklist:

- [x] `This code` follows the style guidelines of this project
- [x] `This code` is self-reviewed
- [x] `This code` is commented, __particularly in hard-to-understand areas__
- [x] `Documentation` has been updated