### PR TITLE
Enhance/standings cache data restructure

### DIFF
--- a/src/lib/graphql/leagues_table/query.ts
+++ b/src/lib/graphql/leagues_table/query.ts
@@ -1,32 +1,17 @@
-// ... import necessary libraries;
 import { gql } from 'graphql-request';
 
 /**
- * METHOD / GET
- * ~~~~~~~~~~~~~
- * ... ℹ GET ALL of the LEAGUE TABLE DATA from the DB;
- * ... ℹ for the website-platform;
+ * [ℹ] Surgical #1 (MAIN)
+ * [ℹ] standings query
 */
-export const GET_LEAGUES_TABLE_DATA = gql`
-	query GET_LEAGUES_TABLE_DATA @cached(ttl: 300) {
-    scores_football_leagues_dev {
-      country
-      data
-      name
-      id
-      season
-      seasons
-    }
-    scores_football_standings_dev {
-      data
-      id
-      name
-      type
-    }
-    scores_football_teams_dev {
-      data
-      id
-      name
+export const REDIS_CACHE_LEAGUES_TABLE_DATA_1 = gql`
+	query REDIS_CACHE_LEAGUES_TABLE_DATA_1 
+    @cached
+    (ttl: 300) 
+  {
+    leagues_filtered_country {
+      lang
+      leagues
     }
     scores_standings_home_widget_translations_dev {
       games
@@ -38,9 +23,77 @@ export const GET_LEAGUES_TABLE_DATA = gql`
       color_codes
       sports
     }
-    leagues_filtered_country {
-      lang
-      leagues
+	}
+`;
+
+/**
+ * [ℹ] Surgical #2 (ALL)
+ * [ℹ] standings query
+ * [ℹ] Based on League ID
+*/
+export const REDIS_CACHE_LEAGUES_TABLE_DATA_2 = gql`
+	query REDIS_CACHE_LEAGUES_TABLE_DATA_2
+    (
+      $leagueIds: [numeric!]
+    )
+    @cached
+    (ttl: 300) 
+  {
+    scores_football_leagues_dev (
+      where: {
+        id: {
+          _in: $leagueIds
+        }
+      }
+    )
+    { # [ℹ] BY LEAGUE ID
+      country
+      data
+      name
+      id
+      season
+      seasons
+    }
+    scores_football_standings_dev (
+      where: {
+        id: {
+          _in: $leagueIds
+        }
+      }
+    )
+    { # [ℹ] BY LEAGUE ID
+      data
+      id
+      name
+      type
+    }
+	}
+`;
+
+/**
+ * [ℹ] Surgical #1 (MAIN)
+ * [ℹ] standings query
+ * [ℹ] Based on Team ID
+*/
+export const REDIS_CACHE_LEAGUES_TABLE_DATA_3 = gql`
+	query REDIS_CACHE_LEAGUES_TABLE_DATA_3
+    (
+      $teamIds: [numeric!]
+    ) 
+    @cached
+    (ttl: 300) 
+  {
+    scores_football_teams_dev (
+      where: {
+        id: {
+          _in: $teamIds
+        }
+      }
+    )
+    { # [ℹ] BY TEAM ID
+      data
+      id
+      name
     }
 	}
 `;

--- a/src/lib/models/hasura.ts
+++ b/src/lib/models/hasura.ts
@@ -393,7 +393,7 @@ export interface BETARENA_HASURA_scores_football_leagues {
   season?:  ScoresFootballLeaguesSeasonElement;
   seasons?: ScoresFootballLeaguesSeasonElement[];
 } export interface ScoresFootballLeaguesDataClass {
-  extra?:      Extra | null;
+  extra?:      ScoresFootballLeaguesExtra | null;
   image_path?: string;
   name?:       string;
   id?:         number;
@@ -410,30 +410,30 @@ export interface BETARENA_HASURA_scores_football_leagues {
 } export interface ScoresFootballLeaguesData {
   legacy_id?:         number;
   country_id?:        number;
-  season?:            DataSeason;
-  country?:           DataCountry;
+  season?:            ScoresFootballLeaguesDataSeason;
+  country?:           ScoresFootballLeaguesDataCountry;
   current_stage_id?:  number;
   is_cup?:            boolean;
-  coverage?:          Coverage;
+  coverage?:          ScoresFootballLeaguesCoverage;
   live_standings?:    boolean;
   active?:            boolean;
   name?:              string;
   is_friendly?:       boolean;
   id?:                number;
   type?:              string;
-  seasons?:           Seasons;
+  seasons?:           ScoresFootballLeaguesSeasons;
   current_round_id?:  null;
   current_season_id?: number;
   logo_path?:         string;
 } export interface ScoresFootballLeaguesDataCountry {
-  data?: DataClass;
+  data?: ScoresFootballLeaguesDataClass;
 } export interface ScoresFootballLeaguesCoverage {
   topscorer_assists?: boolean;
   topscorer_goals?:   boolean;
   predictions?:       boolean;
   topscorer_cards?:   boolean;
 } export interface ScoresFootballLeaguesDataSeason {
-  data?: SeasonElement;
+  data?: ScoresFootballLeaguesSeasonElement;
 } export interface ScoresFootballLeaguesSeasonElement {
   league_id?:         number;
   current_stage_id?:  number | null;
@@ -442,7 +442,7 @@ export interface BETARENA_HASURA_scores_football_leagues {
   is_current_season?: boolean;
   current_round_id?:  number | null;
 } export interface ScoresFootballLeaguesSeasons {
-  data?: SeasonElement[];
+  data?: ScoresFootballLeaguesSeasonElement[];
 }
 
 /**
@@ -774,4 +774,14 @@ export interface BETARENA_HASURA_scores_tournaments {
   it?: string;
   pt?: string;
   ro?: string;
+}
+
+/**
+ * [ℹ] HASURA: scores_standings_home_widget_translations (&_dev)
+*/
+export interface BETARENA_HASURA_scores_standings_home_widget_translations {
+  games: string
+  lang: string
+  points: string
+  title: string
 }

--- a/src/lib/models/leagues_table/types.ts
+++ b/src/lib/models/leagues_table/types.ts
@@ -1,114 +1,56 @@
-// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-// ... ℹ DATA obtained from HASURA [!]
-export interface Hasura_Complete_Leagues_Table_Type {
-    scores_football_leagues_dev: {
-      country: JSON
-      data: JSON
-      name: string
-      id: number
-      season: JSON
-      seasons: JSON
-    }[]
-    scores_football_standings_dev: {
-        id: number
-        type: string
-        name: string
-        data: {
-          // ... <here> more pontetial data is accessible;
-          // ... <here> that was omitted;
-          stage_name: string
-          round_name: number
-          league_id: number
-          round_id: number
-          name: string
-          season_id: number
-          standings: {
-            data: {
-              status: string
-              team_id: number
-              points: number
-              home: {
-                lost: number
-                points: number
-                won: number
-                games_played: number
-                goals_scored: number
-                draw: number
-                goals_against: number
-              }
-              round_name: number
-              team_name: string
-              round_id: number
-              away: {
-                lost: number
-                points: number
-                won: number
-                games_played: number
-                goals_scored: number
-                draw: number
-                goals_against: number
-              }
-              result: string
-              overall: {
-                lost: number
-                points: number
-                won: number
-                games_played: number
-                goals_scored: number
-                draw: number
-                goals_against: number
-              }
-              group_name: string
-              recent_form: string
-              total: {
-                points: number
-                goal_difference: number
-              }
-              group_id: string
-              position: number
-            }[]
-          }
-        }[]
-    }[]
-    scores_football_teams_dev: {
-        id: number
-        name: string
-        data: {
-          legacy_id: number
-          founded: number,
-          country_id: number,
-          twitter: string,
-          national_team: boolean,
-          name: string,
-          venue_id: number,
-          id: number,
-          short_code: string,
-          is_placeholder: boolean,
-          current_season_id: number,
-          logo_path: string
-        }
-    }[]
-    scores_standings_home_widget_translations_dev: {
-      games: string
-      lang: string
-      points: string
-      title: string
-    }[]
-    color_codes_league_standings_positions_dev: {
-      color_codes: JSON
-      sports: string
-    }[]
-    leagues_filtered_country: {
-        lang: string
-        leagues: {
-            league_id: number
-        }[]
-    }[]
+import type { 
+  BETARENA_HASURA_color_codes_league_standings_positions, 
+  BETARENA_HASURA_leagues_filtered_country, 
+  BETARENA_HASURA_scores_football_leagues, 
+  BETARENA_HASURA_scores_football_standings, 
+  BETARENA_HASURA_scores_football_teams, 
+  BETARENA_HASURA_scores_standings_home_widget_translations
+} from "../hasura"
+
+/**
+ * ==========================================
+ * HASURA DB - COMPLETE WIDGET REQUIRED DATA 
+ * ========================================== 
+*/
+
+export interface BETARENA_HASURA_standings_query {
+  leagues_filtered_country:                       BETARENA_HASURA_leagues_filtered_country[]
+  color_codes_league_standings_positions_dev:     BETARENA_HASURA_color_codes_league_standings_positions[]
+  scores_standings_home_widget_translations_dev:  BETARENA_HASURA_scores_standings_home_widget_translations[]
+
+  scores_football_leagues_dev:                    BETARENA_HASURA_scores_football_leagues[]
+  scores_football_standings_dev:                  BETARENA_HASURA_scores_football_standings[]    
+
+  scores_football_teams_dev:                      BETARENA_HASURA_scores_football_teams[]
 }
 
+/**
+ * ==========================================
+ * CACHING PERSIST - COMPLETE WIDGET REQUIRED DATA 
+ * ========================================== 
+*/
 
-// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-// ... ℹ DATA individual types for CAHCE DECLARATION [!]
+export interface Cache_Single_Geo_Leagues_Table_Translation_Response {
+  lang: string
+  top_leagues_table_data: Single_League_Table_Data[]
+}
+
+export interface Cache_Single_Lang_Leagues_Table_Translation_Response {
+  top_leagues_table_data: Single_League_Table_Data[]
+  translations: Single_League_Table_Translations
+}
+
+export interface Leagues_Table_SEO_Cache_Ready {
+  top_leagues_table_data: Single_League_Table_Data[]
+  translations: Single_League_Table_Translations[]
+}
+
+/**
+ * ==========================================
+ * OTHER CACHE INTERFACES - COMPLETE WIDGET REQUIRED DATA 
+ * ========================================== 
+*/
+
 export interface Single_Team_Object_Data {
   position: number
   team_logo:  string
@@ -130,27 +72,4 @@ export interface Single_League_Table_Translations {
   games: string
   points: string
   title: string
-}
-
-
-// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-// ... ℹ generated best goalscorers cache object;
-export interface Cache_Single_Geo_Leagues_Table_Translation_Response {
-  lang: string
-  top_leagues_table_data: Single_League_Table_Data[]
-}
-
-// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-// ... ℹ generated best goalscoreres cache SEO object
-export interface Cache_Single_Lang_Leagues_Table_Translation_Response {
-  top_leagues_table_data: Single_League_Table_Data[]
-  translations: Single_League_Table_Translations
-}
-
-
-// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-// ... ℹ generated best goalscoreres cache SEO object
-export interface Leagues_Table_SEO_Cache_Ready {
-  top_leagues_table_data: Single_League_Table_Data[]
-  translations: Single_League_Table_Translations[]
 }


### PR DESCRIPTION
# 📃 Description

- @migbash updating `leagues_table` / `standings` widget to consume less data through targeted data querying and updating
- @migbash updating `queries` structure for `leagues_table` data gathering through `GraphQL` chunking
- @migbash simultaneous data generation of `seo / translations` & `geo-positional` data

**Fixes** 

- #556 

## ℹ Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# 🧰 How Has This Been Tested?

- [x] `local-testing`

# ✔ Checklist:

- [x] `This code` follows the style guidelines of this project
- [x] `This code` is self-reviewed
- [x] `This code` is commented, __particularly in hard-to-understand areas__
- [x] `Documentation` has been updated
- [x] `This code` does not generate new warnings