### PR TITLE
Update/minor fixture links issues

### DIFF
--- a/src/lib/components/home/live_scores_football/_LiveScores_Widget.svelte
+++ b/src/lib/components/home/live_scores_football/_LiveScores_Widget.svelte
@@ -371,7 +371,7 @@ $: if (refresh_data) {
 						<div class="game-status">{g.status.toLowerCase()}</div>
 					{/if}
 				</div>
-				<a aria-label="Teams" class="game-teams" target="_blank" href="{g.links ? g.links[server_side_language]:''}">
+				<a aria-label="Teams" class="game-teams" target="_self" href="{g.links ? g.links[server_side_language]:''}">
 					<div class="team first {g.localScore < g.visitorScore ? 'loser':''} {g.localScore == g.visitorScore ? 'tie':''}"><span class="teamname">{g.localteam}</span>
 						<span class="cards">
 							{#if g.homeCards > 0}

--- a/src/lib/components/tournaments_page/fixtures_odds/_Fixture_Odds_Widget.svelte
+++ b/src/lib/components/tournaments_page/fixtures_odds/_Fixture_Odds_Widget.svelte
@@ -1798,9 +1798,8 @@
                         fixture?.fixture_link && 
                         fixture?.fixture_link[server_side_language]}
                         <a 
-                          rel="nofollow"
+                          data-sveltekit-prefetch
                           href={fixture?.fixture_link[server_side_language]}
-                          target="_blank"
                           style="width: inherit;">
                           <div
                             class="column-start-grid-start fixture-teams-box">
@@ -2057,10 +2056,9 @@
                         fixture?.fixture_link && 
                         fixture?.fixture_link[server_side_language]}
                         <a 
-                          rel="nofollow"
-                          aria-label="media_link_redirect"
+                          data-sveltekit-prefetch
                           href={fixture?.fixture_link[server_side_language]}
-                          target="_blank"
+                          aria-label="media_link_redirect"
                           style="width: inherit;">
                           <div
                             class="media-play-btn m-r-16">
@@ -2250,9 +2248,8 @@
                         fixture?.fixture_link && 
                         fixture?.fixture_link[server_side_language]}
                         <a 
-                          rel="nofollow"
+                          data-sveltekit-prefetch
                           href={fixture?.fixture_link[server_side_language]}
-                          target="_blank"
                           style="width: inherit;">
                           <div
                             class="column-start-grid-start fixture-teams-box">

--- a/src/lib/models/tournaments/fixtures_odds/types.ts
+++ b/src/lib/models/tournaments/fixtures_odds/types.ts
@@ -11,6 +11,7 @@ import type {
   MediaLinkWelcome,
   Round,
   Time,
+  Urls,
   Weekdays,
   WelcomeMonths,
   WidgetsNoDataAvailable,
@@ -109,7 +110,7 @@ export interface Tournament_Fixture_Odds {
   }
 
   tip_link:     string                // Tip = tip_link_wp + scores_general_translations
-  fixture_link: string                // Fixture Link = fixture_link_wp
+  fixture_link: Urls                  // Fixture Link = fixture_link_wp NOTE: now official-new FIXTURE-LINKS
   media_link:   MediaLinkWelcome[]    // media_link = historic_fixtures + media_link + "video_link"
   bet_icon?:    string                // Betting Site Icon = sportsbook_details (GEO or forced header option)
                                       // [❔] only 1 betting site at the moment for all fixtures of X GEO (design is wrong)


### PR DESCRIPTION
# 📃 Description

- @migbash update to use `_self` instead of the other `betarena` fixtures content link use for navigation to `fixture-pages`

**Fixes** 

- #876 
- #868 

## ℹ Type of change

- [x] 🚀 New feature (non-breaking change which adds functionality)
- [x] ❌ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📃 This change requires a documentation update

# 🧰 How Has This Been Tested?

- [x] `local-testing`
- [ ] `heroku-local-environment-tested`

# ✔ Checklist:

- [x] `This code` follows the style guidelines of this project
- [x] `This code` is self-reviewed
- [x] `This code` is commented, __particularly in hard-to-understand areas__
- [x] `Documentation` has been updated
- [x] `This code` does not generate new warnings

# ⚠ Warning:

Please ensure that your code does not contain `console` without the `if (dev) console...`
to avoid memory overflows on the server. Or remove the `console` if no longer needed.

Please ensure that any `GraphQL` query used starts with the `prefix` - `REDIS_CACHE_` or `FRONTEND_`